### PR TITLE
Implement carousel and modal for experience cards

### DIFF
--- a/src/pages/portfolio/Card.js
+++ b/src/pages/portfolio/Card.js
@@ -1,10 +1,31 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { VerticalTimelineElement } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
 import "./style.css";
 
 const ExperienceCard = ({ theme, experience }) => {
   const { period, icon, company, position, points, techStack, location, info, image } = experience;
+  const images = useMemo(() => (Array.isArray(image) ? image : image ? [image] : []), [image]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+    if (images.length <= 1) return;
+
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % images.length);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [images]);
+
+  const handleImageClick = () => {
+    if (!images.length) return;
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => setIsModalOpen(false);
 
   return (
     <VerticalTimelineElement
@@ -46,17 +67,45 @@ const ExperienceCard = ({ theme, experience }) => {
             {techStack.apis && <p>APIs: {techStack.apis.join(", ")}</p>}
           </div>
         )}
-        {image && (
-          <div className="experience-images">
-            {(Array.isArray(image) ? image : [image]).map((src, idx) => (
+        {!!images.length && (
+          <div className="experience-carousel">
+            <div className="carousel-image-wrapper">
               <img
-                key={idx}
-                src={src}
-                alt={`${company} showcase ${idx + 1}`}
+                src={images[currentIndex]}
+                alt={`${company} showcase ${currentIndex + 1}`}
                 className="experience-image"
                 loading="lazy"
+                onClick={handleImageClick}
               />
-            ))}
+            </div>
+            {images.length > 1 && (
+              <div className="carousel-indicators">
+                {images.map((_, idx) => (
+                  <button
+                    key={idx}
+                    type="button"
+                    className={`carousel-indicator ${idx === currentIndex ? "active" : ""}`}
+                    onClick={() => setCurrentIndex(idx)}
+                    aria-label={`Mostrar imagen ${idx + 1}`}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {isModalOpen && (
+          <div className="image-modal" role="dialog" aria-modal="true" onClick={closeModal}>
+            <div className="image-modal-content" onClick={(e) => e.stopPropagation()}>
+              <button className="image-modal-close" type="button" onClick={closeModal} aria-label="Cerrar">
+                ×
+              </button>
+              <img
+                src={images[currentIndex]}
+                alt={`${company} showcase enlarged ${currentIndex + 1}`}
+                className="image-modal-img"
+                loading="lazy"
+              />
+            </div>
           </div>
         )}
         {info && (

--- a/src/pages/portfolio/style.css
+++ b/src/pages/portfolio/style.css
@@ -50,20 +50,95 @@
   height: auto;
 }
 
-.experience-images {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.experience-carousel {
+  position: relative;
   margin-top: 16px;
 }
 
-.experience-image {
-  border-radius: 8px;
+.carousel-image-wrapper {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  flex: 1 1 150px;
-  max-width: 100%;
-  height: auto;
+}
+
+.experience-image {
+  display: block;
+  width: 100%;
+  height: 260px;
   object-fit: cover;
+  cursor: pointer;
+  transition: transform 0.4s ease;
+}
+
+.experience-image:hover {
+  transform: scale(1.02);
+}
+
+.carousel-indicators {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.carousel-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.carousel-indicator.active,
+.carousel-indicator:hover {
+  background-color: #17a2b8;
+  transform: scale(1.1);
+}
+
+.image-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 9999;
+}
+
+.image-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  background: #000;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.image-modal-img {
+  display: block;
+  max-width: 85vw;
+  max-height: 80vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+}
+
+.image-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.75rem;
+  cursor: pointer;
+  line-height: 1;
 }
 .experience-icon {
   border-radius: 50%;
@@ -101,7 +176,7 @@
 
 @media (max-width: 576px) {
   .experience-image {
-    flex: 1 1 100%;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an automatic carousel for experience card images with manual indicator selection
- enable clicking the carousel image to view it in a modal overlay
- style the carousel, indicators, and modal for desktop and mobile breakpoints

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5685569ac8326a698fb46959aa8cc