### PR TITLE
Add dedicated services catalog page

### DIFF
--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -5,6 +5,7 @@ import { Home } from "../pages/home";
 import { Portfolio } from "../pages/portfolio";
 import { ContactUs } from "../pages/contact";
 import { About } from "../pages/about";
+import { Services } from "../pages/services";
 import { Socialicons } from "../components/socialicons";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { Certificates } from "../pages/certificates";
@@ -24,6 +25,7 @@ const AnimatedRoutes = withRouter(({ location , theme}) => (
         <Route exact path="/" element={<Home />} />
         <Route path="/about" element={<About />} />
         <Route path="/portfolio" element={<Portfolio theme={theme} />} />
+        <Route path="/services" element={<Services />} />
         <Route path="/certificates" element={<Certificates />} />
         <Route path="/contact" element={<ContactUs />} />
         <Route path="*" element={<Home />} />

--- a/src/header/index.js
+++ b/src/header/index.js
@@ -40,6 +40,9 @@ const Headermain = ({theme, settheme}) => {
                   <Link  onClick={handleToggle} to="/" className="my-3">Home</Link>
                   </li>
                   <li className="menu_item">
+                  <Link onClick={handleToggle} to="/services" className="my-3">Servicios</Link>
+                  </li>
+                  <li className="menu_item">
                   <Link onClick={handleToggle} to="/portfolio" className="my-3">My Professional Timeline</Link>
                   </li>
                   <li className="menu_item">

--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -4,298 +4,300 @@ import { Helmet, HelmetProvider } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import { meta } from "../../content_option";
 
+const CALENDLY_URL = "https://calendly.com/serralta-ivan/personal";
+
 const serviceCatalog = [
   {
     id: "saas",
     icon: "🧩",
     title: "SaaS & Web Apps",
-    subtitle: "Desarrollo de plataformas SaaS y paneles administrativos completos.",
+    subtitle: "Development of SaaS platforms and complete admin dashboards.",
     services: [
       {
-        name: "Desarrollo de Dashboard SaaS",
+        name: "SaaS Dashboard Development",
         description:
-          "Implementación de paneles en Next.js con autenticación, métricas clave, suscripciones y administración.",
+          "Implementation of dashboards in Next.js with authentication, key metrics, subscriptions, and admin tools.",
         benefits: [
-          "Login seguro con gestión de usuarios",
-          "Panel de métricas en tiempo real",
-          "Cobros recurrentes integrados con Stripe",
+          "Secure login with user management",
+          "Real-time metrics panel",
+          "Recurring billing integrated with Stripe",
         ],
         technologies: ["Next.js", "Firebase", "Stripe"],
       },
       {
-        name: "Panel Admin personalizado",
+        name: "Custom Admin Panel",
         description:
-          "Control interno con gestión de roles, permisos y reportes adaptados a tu operación.",
+          "Internal control with role management, permissions, and reports tailored to your operation.",
         benefits: [
-          "Roles avanzados y auditoría",
-          "Reportes exportables",
-          "Onboarding guiado para equipos",
+          "Advanced roles and auditing",
+          "Exportable reports",
+          "Guided onboarding for teams",
         ],
         technologies: ["React", "Node.js", "Prisma", "PostgreSQL"],
       },
       {
-        name: "MVP SaaS desde cero",
-        description: "Prototipo funcional y desplegado en menos de 3 semanas.",
+        name: "SaaS MVP from Scratch",
+        description: "Functional prototype launched in under 3 weeks.",
         benefits: [
-          "Arquitectura escalable desde el inicio",
-          "Entrega continua y documentación",
-          "Incluye pipelines de CI/CD y monitoreo",
+          "Scalable architecture from day one",
+          "Continuous delivery and documentation",
+          "Includes CI/CD pipelines and monitoring",
         ],
         technologies: ["Next.js", "Node.js", "AWS", "Prisma"],
       },
     ],
     footer: {
-      focus: "Enfocado en startups, agencias y empresas sin CTO.",
-      cta: "Agendar reunión",
+      focus: "Focused on startups, agencies, and companies without a CTO.",
+      cta: "Book a call",
     },
   },
   {
     id: "automation",
     icon: "⚙️",
-    title: "Automatización y APIs",
-    subtitle: "Integraciones seguras para reducir tareas repetitivas y conectar tus sistemas.",
+    title: "Automation & APIs",
+    subtitle: "Secure integrations to cut repetitive tasks and connect your systems.",
     services: [
       {
-        name: "Integración de APIs REST / WebSockets",
+        name: "REST / WebSocket API Integrations",
         description:
-          "Conecto plataformas como Stripe, Shopify, MercadoPago o MetaTrader con tu producto.",
+          "Connect platforms like Stripe, Shopify, MercadoPago, or MetaTrader with your product.",
         benefits: [
-          "Logs centralizados y manejo de errores",
-          "Autenticación segura y escalable",
-          "Monitoreo continuo de integraciones",
+          "Centralized logs and error handling",
+          "Secure and scalable authentication",
+          "Continuous integration monitoring",
         ],
         technologies: ["Node.js", "Python", "Firebase"],
       },
       {
-        name: "Automatización de workflows SaaS",
+        name: "SaaS Workflow Automation",
         description:
-          "Sincronizo CRM, facturación y notificaciones con jobs programados y webhooks.",
+          "Sync CRM, billing, and notifications with scheduled jobs and webhooks.",
         benefits: [
-          "Ahorro de tiempo en tareas repetitivas",
-          "Reducción de errores humanos",
-          "Trazabilidad completa de procesos",
+          "Time savings on repetitive tasks",
+          "Reduced human errors",
+          "Full process traceability",
         ],
         technologies: ["Node.js", "cron jobs", "n8n", "Zapier"],
       },
       {
-        name: "Microservicios y scripts a medida",
+        name: "Custom Microservices and Scripts",
         description:
-          "Automatizaciones personalizadas listas para ejecutar en AWS Lambda o contenedores.",
+          "Custom automations ready to run on AWS Lambda or containers.",
         benefits: [
-          "Escalado automático",
-          "Alertas y métricas integradas",
-          "Mantenimiento sencillo",
+          "Automatic scaling",
+          "Built-in alerts and metrics",
+          "Simple maintenance",
         ],
         technologies: ["AWS", "Python", "Node.js"],
       },
     ],
     footer: {
-      focus: "Beneficios: ahorro de tiempo, reducción de errores y trazabilidad.",
-      cta: "Solicitar presupuesto",
+      focus: "Benefits: time savings, fewer errors, and full traceability.",
+      cta: "Request a quote",
     },
   },
   {
     id: "trading",
     icon: "💸",
     title: "Trading & FinTech Solutions",
-    subtitle: "Sistemas automatizados para trading y gestión de cuentas con métricas en vivo.",
+    subtitle: "Automated systems for trading and account management with live metrics.",
     services: [
       {
-        name: "Integración con MetaTrader (MT4/MT5)",
+        name: "MetaTrader Integration (MT4/MT5)",
         description:
-          "Bridge seguro para ejecutar operaciones desde web o backend hacia tus cuentas de trading.",
+          "Secure bridge to execute trades from web or backend into your trading accounts.",
         benefits: [
-          "Ejecución en milisegundos",
-          "Logs y auditorías por operación",
-          "Soporte multi-cuenta",
+          "Millisecond execution",
+          "Logs and audits per trade",
+          "Multi-account support",
         ],
         technologies: ["MetaApi", "MT4", "MT5", "Node.js"],
       },
       {
-        name: "Panel de métricas y control de fondeo",
+        name: "Funding Control & Metrics Dashboard",
         description:
-          "Panel tipo FTMO con visualización de balance, equity, drawdown y objetivos personalizados.",
+          "FTMO-style dashboard with balance, equity, drawdown, and custom goals.",
         benefits: [
-          "Alertas en tiempo real",
-          "Dashboards responsivos",
-          "Reportes descargables",
+          "Real-time alerts",
+          "Responsive dashboards",
+          "Downloadable reports",
         ],
         technologies: ["Next.js", "AWS", "PostgreSQL"],
       },
       {
-        name: "Trading Bot personalizado",
+        name: "Custom Trading Bot",
         description:
-          "Estrategias automatizadas en Python o Node.js con indicadores técnicos y control de riesgo.",
+          "Automated strategies in Python or Node.js with technical indicators and risk control.",
         benefits: [
-          "Backtesting con datos históricos",
-          "Gestión de riesgo configurable",
-          "Deploy automatizado",
+          "Backtesting with historical data",
+          "Configurable risk management",
+          "Automated deployment",
         ],
         technologies: ["Python", "Node.js", "AWS Lambda"],
       },
     ],
     footer: {
-      focus: "Clientes ideales: traders, brokers y startups fintech.",
-      cta: "Agendar reunión",
+      focus: "Ideal for traders, brokers, and fintech startups.",
+      cta: "Book a call",
     },
   },
   {
     id: "ecommerce",
     icon: "🛍️",
     title: "E-commerce & Marketplace Automation",
-    subtitle: "Conecto tus tiendas con sistemas externos para automatizar pagos, stock y notificaciones.",
+    subtitle: "Connect your stores with external systems to automate payments, inventory, and notifications.",
     services: [
       {
-        name: "Integración Shopify / Mirakl",
+        name: "Shopify / Mirakl Integration",
         description:
-          "Vinculo tu e-commerce con ERP, CRM u otros sistemas para centralizar información.",
+          "Link your e-commerce with ERP, CRM, or other systems to centralize information.",
         benefits: [
-          "Catálogo sincronizado",
-          "Actualización automática de stock",
-          "Pedidos unificados",
+          "Synced catalog",
+          "Automatic inventory updates",
+          "Unified orders",
         ],
         technologies: ["Shopify API", "Node.js", "Firebase"],
       },
       {
-        name: "Automatización de pagos y envíos",
+        name: "Payments and Shipping Automation",
         description:
-          "Configuro flujos con Stripe, MercadoPago y PayPal para pagos, facturas y notificaciones.",
+          "Configure flows with Stripe, MercadoPago, and PayPal for payments, invoices, and notifications.",
         benefits: [
-          "Pagos confirmados en tiempo real",
-          "Alertas de inventario",
-          "Emails transaccionales",
+          "Real-time payment confirmation",
+          "Inventory alerts",
+          "Transactional emails",
         ],
         technologies: ["Stripe", "MercadoPago", "PayPal"],
       },
       {
-        name: "Gestión centralizada de catálogos",
+        name: "Centralized Catalog Management",
         description:
-          "Administra productos y pedidos desde un único panel con roles y permisos.",
+          "Manage products and orders from a single panel with roles and permissions.",
         benefits: [
-          "Curva de aprendizaje mínima",
-          "Control multi-tienda",
-          "Historial y trazabilidad",
+          "Minimal learning curve",
+          "Multi-store control",
+          "History and traceability",
         ],
         technologies: ["Next.js", "Node.js", "PostgreSQL"],
       },
     ],
     footer: {
-      focus: "Stack sugerido: Node.js, Next.js, Shopify API, MercadoPago API, Stripe, Firebase.",
-      cta: "Solicitar presupuesto",
+      focus: "Suggested stack: Node.js, Next.js, Shopify API, MercadoPago API, Stripe, Firebase.",
+      cta: "Request a quote",
     },
   },
   {
     id: "devops",
     icon: "🧠",
     title: "DevOps & Cloud Infrastructure",
-    subtitle: "Entornos escalables, seguros y automatizados listos para producción.",
+    subtitle: "Scalable, secure, and automated environments ready for production.",
     services: [
       {
-        name: "Configuración AWS completa",
+        name: "Full AWS Setup",
         description:
-          "Infraestructura con Lambda, EC2, S3, RDS y pipelines CI/CD listos para tu equipo.",
+          "Infrastructure with Lambda, EC2, S3, RDS, and CI/CD pipelines ready for your team.",
         benefits: [
-          "Infraestructura como código",
-          "Seguridad y backups automatizados",
-          "Monitoreo con CloudWatch",
+          "Infrastructure as code",
+          "Automated security and backups",
+          "Monitoring with CloudWatch",
         ],
         technologies: ["AWS", "CloudFormation", "GitHub Actions"],
       },
       {
-        name: "Deploy automatizado",
+        name: "Automated Deployments",
         description:
-          "Pipelines para Vercel, Docker o Railway con rollbacks y revisión previa.",
+          "Pipelines for Vercel, Docker, or Railway with rollbacks and pre-release review.",
         benefits: [
-          "Entregas continuas",
-          "Versionado y aprobaciones",
-          "Observabilidad integrada",
+          "Continuous delivery",
+          "Versioning and approvals",
+          "Built-in observability",
         ],
         technologies: ["Docker", "Railway", "Vercel"],
       },
       {
-        name: "Monitoreo, logs y backups",
+        name: "Monitoring, Logs & Backups",
         description:
-          "Implemento dashboards, alertas y backups automáticos para mantener tu uptime.",
+          "Implement dashboards, alerts, and automated backups to keep your uptime high.",
         benefits: [
-          "Alertas proactivas",
-          "Historico de logs centralizado",
-          "Recuperación ante desastres",
+          "Proactive alerts",
+          "Centralized log history",
+          "Disaster recovery",
         ],
         technologies: ["CloudWatch", "Grafana", "AWS Backup"],
       },
     ],
     footer: {
       focus: "Stack: AWS, Railway, GitHub Actions, Docker, CloudWatch.",
-      cta: "Agendar reunión",
+      cta: "Book a call",
     },
   },
   {
     id: "consulting",
     icon: "👨‍💼",
     title: "Consulting & Technical Leadership",
-    subtitle: "Acompañamiento técnico para founders y equipos que necesitan dirección.",
+    subtitle: "Technical support for founders and teams that need direction.",
     services: [
       {
         name: "CTO-as-a-Service",
         description:
-          "Mentoría técnica continua para definir roadmap, contratar talento y escalar productos.",
+          "Ongoing technical mentorship to define roadmap, hire talent, and scale products.",
         benefits: [
-          "Reuniones semanales personalizadas",
-          "Seguimiento de OKRs técnicos",
-          "Red de partners y proveedores",
+          "Weekly tailored meetings",
+          "Tracking of technical OKRs",
+          "Network of partners and vendors",
         ],
         technologies: ["Notion", "Linear", "Slack"],
       },
       {
-        name: "Revisión de arquitectura",
+        name: "Architecture Review",
         description:
-          "Auditoría de código y arquitectura para detectar riesgos y oportunidades.",
+          "Code and architecture audit to identify risks and opportunities.",
         benefits: [
-          "Reporte ejecutivo con hallazgos",
-          "Prioridades claras y plan de acción",
-          "Sesión de revisión con tu equipo",
+          "Executive report with findings",
+          "Clear priorities and action plan",
+          "Review session with your team",
         ],
         technologies: ["AWS", "Next.js", "Node.js"],
       },
       {
-        name: "Planificación de roadmap",
+        name: "Roadmap Planning",
         description:
-          "Diseño de roadmap técnico con estimaciones, milestones y dependencias.",
+          "Design of a technical roadmap with estimates, milestones, and dependencies.",
         benefits: [
-          "Workshops colaborativos",
-          "Roadmap en herramientas colaborativas",
-          "Seguimiento quincenal",
+          "Collaborative workshops",
+          "Roadmap in collaborative tools",
+          "Bi-weekly follow-up",
         ],
         technologies: ["Notion", "Miro", "Jira"],
       },
     ],
     footer: {
-      focus: "Ideal para fundadores, startups sin equipo técnico y agencias.",
-      cta: "Agendar reunión",
+      focus: "Ideal for founders, startups without a technical team, and agencies.",
+      cta: "Book a call",
     },
   },
 ];
 
 const extras = {
-  title: "Extras / Complementos opcionales",
+  title: "Extras / Optional Add-ons",
   icon: "🌐",
   description:
-    "Complementos perfectos para ampliar tu proyecto o preparar un roadmap de mejoras.",
+    "Perfect add-ons to expand your project or prepare a roadmap of improvements.",
   services: [
     {
-      name: "Setup de autenticación segura",
+      name: "Secure Authentication Setup",
       technologies: ["Firebase", "Auth0", "JWT"],
     },
     {
-      name: "Notificaciones push multicanal",
+      name: "Multi-channel Push Notifications",
       technologies: ["FCM", "OneSignal"],
     },
     {
-      name: "Dashboards responsivos y UI personalizada",
+      name: "Responsive Dashboards and Custom UI",
       technologies: ["Tailwind CSS", "shadcn/ui"],
     },
     {
-      name: "Integración con Google Sheets / Notion / CRMs",
+      name: "Google Sheets / Notion / CRM Integrations",
       technologies: ["Google Sheets API", "Notion API", "Zapier"],
     },
   ],
@@ -307,27 +309,32 @@ export const Services = () => {
       <section className="services-page">
         <Helmet>
           <meta charSet="utf-8" />
-          <title>Servicios | {meta.title}</title>
+          <title>Services | {meta.title}</title>
           <meta
             name="description"
-            content="Catálogo de servicios de desarrollo SaaS, automatización, trading, e-commerce y DevOps."
+            content="Service catalog for SaaS development, automation, trading, e-commerce, and DevOps."
           />
         </Helmet>
 
         <div className="services-hero">
           <div className="services-hero__content">
-            <span className="services-hero__eyebrow">Servicios</span>
-            <h1>Construyo sistemas que automatizan negocios.</h1>
+            <span className="services-hero__eyebrow">Services</span>
+            <h1>I build systems that automate businesses.</h1>
             <p>
-              Desarrollo y automatizo productos digitales end-to-end: desde MVPs SaaS hasta infraestructura
-              cloud y automatizaciones de trading.
+              I design and automate end-to-end digital products: from SaaS MVPs to cloud infrastructure and
+              trading automations.
             </p>
             <div className="services-hero__actions">
-              <Link to="/contact" className="services-btn services-btn--primary">
-                Reservá una reunión gratuita de 15 minutos
-              </Link>
+              <a
+                href={CALENDLY_URL}
+                className="services-btn services-btn--primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Book a free 15-minute call
+              </a>
               <Link to="/portfolio" className="services-btn services-btn--ghost">
-                Ver experiencia previa
+                See past work
               </Link>
             </div>
           </div>
@@ -353,7 +360,7 @@ export const Services = () => {
                     </header>
                     <div className="service-item__details">
                       <div>
-                        <h4>Beneficios</h4>
+                        <h4>Benefits</h4>
                         <ul>
                           {service.benefits.map((benefit) => (
                             <li key={benefit}>{benefit}</li>
@@ -361,7 +368,7 @@ export const Services = () => {
                         </ul>
                       </div>
                       <div>
-                        <h4>Tecnologías</h4>
+                        <h4>Technologies</h4>
                         <div className="tech-tags">
                           {service.technologies.map((tech) => (
                             <span key={tech} className="tech-tag">
@@ -377,9 +384,14 @@ export const Services = () => {
 
               <footer className="service-card__footer">
                 <p>{category.footer.focus}</p>
-                <Link to="/contact" className="services-btn services-btn--secondary">
+                <a
+                  href={CALENDLY_URL}
+                  className="services-btn services-btn--secondary"
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   {category.footer.cta}
-                </Link>
+                </a>
               </footer>
             </section>
           ))}
@@ -407,9 +419,14 @@ export const Services = () => {
               </div>
             ))}
           </div>
-          <Link to="/contact" className="services-btn services-btn--primary">
-            Consultar por complementos
-          </Link>
+          <a
+            href={CALENDLY_URL}
+            className="services-btn services-btn--primary"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Ask about add-ons
+          </a>
         </section>
       </section>
     </HelmetProvider>

--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -1,0 +1,419 @@
+import React from "react";
+import "./style.css";
+import { Helmet, HelmetProvider } from "react-helmet-async";
+import { Link } from "react-router-dom";
+import { meta } from "../../content_option";
+
+const serviceCatalog = [
+  {
+    id: "saas",
+    icon: "🧩",
+    title: "SaaS & Web Apps",
+    subtitle: "Desarrollo de plataformas SaaS y paneles administrativos completos.",
+    services: [
+      {
+        name: "Desarrollo de Dashboard SaaS",
+        description:
+          "Implementación de paneles en Next.js con autenticación, métricas clave, suscripciones y administración.",
+        benefits: [
+          "Login seguro con gestión de usuarios",
+          "Panel de métricas en tiempo real",
+          "Cobros recurrentes integrados con Stripe",
+        ],
+        technologies: ["Next.js", "Firebase", "Stripe"],
+      },
+      {
+        name: "Panel Admin personalizado",
+        description:
+          "Control interno con gestión de roles, permisos y reportes adaptados a tu operación.",
+        benefits: [
+          "Roles avanzados y auditoría",
+          "Reportes exportables",
+          "Onboarding guiado para equipos",
+        ],
+        technologies: ["React", "Node.js", "Prisma", "PostgreSQL"],
+      },
+      {
+        name: "MVP SaaS desde cero",
+        description: "Prototipo funcional y desplegado en menos de 3 semanas.",
+        benefits: [
+          "Arquitectura escalable desde el inicio",
+          "Entrega continua y documentación",
+          "Incluye pipelines de CI/CD y monitoreo",
+        ],
+        technologies: ["Next.js", "Node.js", "AWS", "Prisma"],
+      },
+    ],
+    footer: {
+      focus: "Enfocado en startups, agencias y empresas sin CTO.",
+      cta: "Agendar reunión",
+    },
+  },
+  {
+    id: "automation",
+    icon: "⚙️",
+    title: "Automatización y APIs",
+    subtitle: "Integraciones seguras para reducir tareas repetitivas y conectar tus sistemas.",
+    services: [
+      {
+        name: "Integración de APIs REST / WebSockets",
+        description:
+          "Conecto plataformas como Stripe, Shopify, MercadoPago o MetaTrader con tu producto.",
+        benefits: [
+          "Logs centralizados y manejo de errores",
+          "Autenticación segura y escalable",
+          "Monitoreo continuo de integraciones",
+        ],
+        technologies: ["Node.js", "Python", "Firebase"],
+      },
+      {
+        name: "Automatización de workflows SaaS",
+        description:
+          "Sincronizo CRM, facturación y notificaciones con jobs programados y webhooks.",
+        benefits: [
+          "Ahorro de tiempo en tareas repetitivas",
+          "Reducción de errores humanos",
+          "Trazabilidad completa de procesos",
+        ],
+        technologies: ["Node.js", "cron jobs", "n8n", "Zapier"],
+      },
+      {
+        name: "Microservicios y scripts a medida",
+        description:
+          "Automatizaciones personalizadas listas para ejecutar en AWS Lambda o contenedores.",
+        benefits: [
+          "Escalado automático",
+          "Alertas y métricas integradas",
+          "Mantenimiento sencillo",
+        ],
+        technologies: ["AWS", "Python", "Node.js"],
+      },
+    ],
+    footer: {
+      focus: "Beneficios: ahorro de tiempo, reducción de errores y trazabilidad.",
+      cta: "Solicitar presupuesto",
+    },
+  },
+  {
+    id: "trading",
+    icon: "💸",
+    title: "Trading & FinTech Solutions",
+    subtitle: "Sistemas automatizados para trading y gestión de cuentas con métricas en vivo.",
+    services: [
+      {
+        name: "Integración con MetaTrader (MT4/MT5)",
+        description:
+          "Bridge seguro para ejecutar operaciones desde web o backend hacia tus cuentas de trading.",
+        benefits: [
+          "Ejecución en milisegundos",
+          "Logs y auditorías por operación",
+          "Soporte multi-cuenta",
+        ],
+        technologies: ["MetaApi", "MT4", "MT5", "Node.js"],
+      },
+      {
+        name: "Panel de métricas y control de fondeo",
+        description:
+          "Panel tipo FTMO con visualización de balance, equity, drawdown y objetivos personalizados.",
+        benefits: [
+          "Alertas en tiempo real",
+          "Dashboards responsivos",
+          "Reportes descargables",
+        ],
+        technologies: ["Next.js", "AWS", "PostgreSQL"],
+      },
+      {
+        name: "Trading Bot personalizado",
+        description:
+          "Estrategias automatizadas en Python o Node.js con indicadores técnicos y control de riesgo.",
+        benefits: [
+          "Backtesting con datos históricos",
+          "Gestión de riesgo configurable",
+          "Deploy automatizado",
+        ],
+        technologies: ["Python", "Node.js", "AWS Lambda"],
+      },
+    ],
+    footer: {
+      focus: "Clientes ideales: traders, brokers y startups fintech.",
+      cta: "Agendar reunión",
+    },
+  },
+  {
+    id: "ecommerce",
+    icon: "🛍️",
+    title: "E-commerce & Marketplace Automation",
+    subtitle: "Conecto tus tiendas con sistemas externos para automatizar pagos, stock y notificaciones.",
+    services: [
+      {
+        name: "Integración Shopify / Mirakl",
+        description:
+          "Vinculo tu e-commerce con ERP, CRM u otros sistemas para centralizar información.",
+        benefits: [
+          "Catálogo sincronizado",
+          "Actualización automática de stock",
+          "Pedidos unificados",
+        ],
+        technologies: ["Shopify API", "Node.js", "Firebase"],
+      },
+      {
+        name: "Automatización de pagos y envíos",
+        description:
+          "Configuro flujos con Stripe, MercadoPago y PayPal para pagos, facturas y notificaciones.",
+        benefits: [
+          "Pagos confirmados en tiempo real",
+          "Alertas de inventario",
+          "Emails transaccionales",
+        ],
+        technologies: ["Stripe", "MercadoPago", "PayPal"],
+      },
+      {
+        name: "Gestión centralizada de catálogos",
+        description:
+          "Administra productos y pedidos desde un único panel con roles y permisos.",
+        benefits: [
+          "Curva de aprendizaje mínima",
+          "Control multi-tienda",
+          "Historial y trazabilidad",
+        ],
+        technologies: ["Next.js", "Node.js", "PostgreSQL"],
+      },
+    ],
+    footer: {
+      focus: "Stack sugerido: Node.js, Next.js, Shopify API, MercadoPago API, Stripe, Firebase.",
+      cta: "Solicitar presupuesto",
+    },
+  },
+  {
+    id: "devops",
+    icon: "🧠",
+    title: "DevOps & Cloud Infrastructure",
+    subtitle: "Entornos escalables, seguros y automatizados listos para producción.",
+    services: [
+      {
+        name: "Configuración AWS completa",
+        description:
+          "Infraestructura con Lambda, EC2, S3, RDS y pipelines CI/CD listos para tu equipo.",
+        benefits: [
+          "Infraestructura como código",
+          "Seguridad y backups automatizados",
+          "Monitoreo con CloudWatch",
+        ],
+        technologies: ["AWS", "CloudFormation", "GitHub Actions"],
+      },
+      {
+        name: "Deploy automatizado",
+        description:
+          "Pipelines para Vercel, Docker o Railway con rollbacks y revisión previa.",
+        benefits: [
+          "Entregas continuas",
+          "Versionado y aprobaciones",
+          "Observabilidad integrada",
+        ],
+        technologies: ["Docker", "Railway", "Vercel"],
+      },
+      {
+        name: "Monitoreo, logs y backups",
+        description:
+          "Implemento dashboards, alertas y backups automáticos para mantener tu uptime.",
+        benefits: [
+          "Alertas proactivas",
+          "Historico de logs centralizado",
+          "Recuperación ante desastres",
+        ],
+        technologies: ["CloudWatch", "Grafana", "AWS Backup"],
+      },
+    ],
+    footer: {
+      focus: "Stack: AWS, Railway, GitHub Actions, Docker, CloudWatch.",
+      cta: "Agendar reunión",
+    },
+  },
+  {
+    id: "consulting",
+    icon: "👨‍💼",
+    title: "Consulting & Technical Leadership",
+    subtitle: "Acompañamiento técnico para founders y equipos que necesitan dirección.",
+    services: [
+      {
+        name: "CTO-as-a-Service",
+        description:
+          "Mentoría técnica continua para definir roadmap, contratar talento y escalar productos.",
+        benefits: [
+          "Reuniones semanales personalizadas",
+          "Seguimiento de OKRs técnicos",
+          "Red de partners y proveedores",
+        ],
+        technologies: ["Notion", "Linear", "Slack"],
+      },
+      {
+        name: "Revisión de arquitectura",
+        description:
+          "Auditoría de código y arquitectura para detectar riesgos y oportunidades.",
+        benefits: [
+          "Reporte ejecutivo con hallazgos",
+          "Prioridades claras y plan de acción",
+          "Sesión de revisión con tu equipo",
+        ],
+        technologies: ["AWS", "Next.js", "Node.js"],
+      },
+      {
+        name: "Planificación de roadmap",
+        description:
+          "Diseño de roadmap técnico con estimaciones, milestones y dependencias.",
+        benefits: [
+          "Workshops colaborativos",
+          "Roadmap en herramientas colaborativas",
+          "Seguimiento quincenal",
+        ],
+        technologies: ["Notion", "Miro", "Jira"],
+      },
+    ],
+    footer: {
+      focus: "Ideal para fundadores, startups sin equipo técnico y agencias.",
+      cta: "Agendar reunión",
+    },
+  },
+];
+
+const extras = {
+  title: "Extras / Complementos opcionales",
+  icon: "🌐",
+  description:
+    "Complementos perfectos para ampliar tu proyecto o preparar un roadmap de mejoras.",
+  services: [
+    {
+      name: "Setup de autenticación segura",
+      technologies: ["Firebase", "Auth0", "JWT"],
+    },
+    {
+      name: "Notificaciones push multicanal",
+      technologies: ["FCM", "OneSignal"],
+    },
+    {
+      name: "Dashboards responsivos y UI personalizada",
+      technologies: ["Tailwind CSS", "shadcn/ui"],
+    },
+    {
+      name: "Integración con Google Sheets / Notion / CRMs",
+      technologies: ["Google Sheets API", "Notion API", "Zapier"],
+    },
+  ],
+};
+
+export const Services = () => {
+  return (
+    <HelmetProvider>
+      <section className="services-page">
+        <Helmet>
+          <meta charSet="utf-8" />
+          <title>Servicios | {meta.title}</title>
+          <meta
+            name="description"
+            content="Catálogo de servicios de desarrollo SaaS, automatización, trading, e-commerce y DevOps."
+          />
+        </Helmet>
+
+        <div className="services-hero">
+          <div className="services-hero__content">
+            <span className="services-hero__eyebrow">Servicios</span>
+            <h1>Construyo sistemas que automatizan negocios.</h1>
+            <p>
+              Desarrollo y automatizo productos digitales end-to-end: desde MVPs SaaS hasta infraestructura
+              cloud y automatizaciones de trading.
+            </p>
+            <div className="services-hero__actions">
+              <Link to="/contact" className="services-btn services-btn--primary">
+                Reservá una reunión gratuita de 15 minutos
+              </Link>
+              <Link to="/portfolio" className="services-btn services-btn--ghost">
+                Ver experiencia previa
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <div className="services-grid">
+          {serviceCatalog.map((category) => (
+            <section key={category.id} className="service-card" id={category.id}>
+              <div className="service-card__header">
+                <span className="service-card__icon" aria-hidden>{category.icon}</span>
+                <div>
+                  <h2>{category.title}</h2>
+                  <p className="service-card__subtitle">{category.subtitle}</p>
+                </div>
+              </div>
+
+              <div className="service-card__body">
+                {category.services.map((service) => (
+                  <article key={service.name} className="service-item">
+                    <header>
+                      <h3>{service.name}</h3>
+                      <p>{service.description}</p>
+                    </header>
+                    <div className="service-item__details">
+                      <div>
+                        <h4>Beneficios</h4>
+                        <ul>
+                          {service.benefits.map((benefit) => (
+                            <li key={benefit}>{benefit}</li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <h4>Tecnologías</h4>
+                        <div className="tech-tags">
+                          {service.technologies.map((tech) => (
+                            <span key={tech} className="tech-tag">
+                              {tech}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+
+              <footer className="service-card__footer">
+                <p>{category.footer.focus}</p>
+                <Link to="/contact" className="services-btn services-btn--secondary">
+                  {category.footer.cta}
+                </Link>
+              </footer>
+            </section>
+          ))}
+        </div>
+
+        <section className="service-extras" id="extras">
+          <div className="service-card__header">
+            <span className="service-card__icon" aria-hidden>{extras.icon}</span>
+            <div>
+              <h2>{extras.title}</h2>
+              <p className="service-card__subtitle">{extras.description}</p>
+            </div>
+          </div>
+          <div className="service-extras__grid">
+            {extras.services.map((service) => (
+              <div key={service.name} className="service-extra">
+                <h3>{service.name}</h3>
+                <div className="tech-tags">
+                  {service.technologies.map((tech) => (
+                    <span key={tech} className="tech-tag">
+                      {tech}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <Link to="/contact" className="services-btn services-btn--primary">
+            Consultar por complementos
+          </Link>
+        </section>
+      </section>
+    </HelmetProvider>
+  );
+};
+
+export default Services;

--- a/src/pages/services/style.css
+++ b/src/pages/services/style.css
@@ -1,0 +1,258 @@
+.services-page {
+  padding: 120px 0 80px;
+}
+
+.services-hero {
+  display: flex;
+  justify-content: center;
+  padding: 0 1.5rem 4rem;
+  text-align: center;
+}
+
+.services-hero__content {
+  max-width: 840px;
+}
+
+.services-hero__eyebrow {
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary-color, #6c63ff);
+  margin-bottom: 0.75rem;
+}
+
+.services-hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.services-hero p {
+  color: var(--text-muted, #6f6f76);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.services-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.services-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  text-decoration: none;
+}
+
+.services-btn--primary {
+  background: linear-gradient(135deg, #6c63ff, #8a74ff);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(108, 99, 255, 0.3);
+}
+
+.services-btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px rgba(108, 99, 255, 0.35);
+}
+
+.services-btn--ghost {
+  border-color: rgba(108, 99, 255, 0.3);
+  color: inherit;
+}
+
+.services-btn--ghost:hover {
+  transform: translateY(-2px);
+  border-color: rgba(108, 99, 255, 0.6);
+}
+
+.services-btn--secondary {
+  border-color: rgba(108, 99, 255, 0.4);
+  color: inherit;
+}
+
+.services-btn--secondary:hover {
+  transform: translateY(-2px);
+  border-color: rgba(108, 99, 255, 0.7);
+  background: rgba(108, 99, 255, 0.08);
+}
+
+.services-grid {
+  display: grid;
+  gap: 2.5rem;
+  padding: 0 1.5rem 4rem;
+}
+
+.service-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 32px;
+  padding: 2.5rem;
+  box-shadow: 0 24px 60px rgba(17, 24, 39, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.service-card__header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.service-card__icon {
+  font-size: 2.5rem;
+}
+
+.service-card__subtitle {
+  color: var(--text-muted, #7d7d85);
+  margin: 0.25rem 0 0;
+}
+
+.service-card__body {
+  display: grid;
+  gap: 1.75rem;
+  margin-bottom: 2rem;
+}
+
+.service-item h3 {
+  font-size: 1.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.service-item p {
+  margin-bottom: 1rem;
+  color: var(--text-muted, #7d7d85);
+}
+
+.service-item__details {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.service-item__details h4 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #7d7d85);
+  margin-bottom: 0.75rem;
+}
+
+.service-item__details ul {
+  padding-left: 1.2rem;
+  margin: 0;
+  color: inherit;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.tech-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tech-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(108, 99, 255, 0.15);
+  color: inherit;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.service-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.5rem;
+}
+
+.service-card__footer p {
+  margin: 0;
+  color: var(--text-muted, #7d7d85);
+}
+
+.service-extras {
+  margin: 0 1.5rem;
+  padding: 2.5rem;
+  border-radius: 32px;
+  background: rgba(108, 99, 255, 0.08);
+  border: 1px solid rgba(108, 99, 255, 0.15);
+  display: grid;
+  gap: 2rem;
+  text-align: center;
+}
+
+.service-extras__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.service-extra {
+  padding: 1.25rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+@media (max-width: 992px) {
+  .services-page {
+    padding-top: 100px;
+  }
+
+  .service-card {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .service-card {
+    padding: 1.75rem;
+  }
+
+  .service-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .service-card__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .services-hero {
+    padding-inline: 1rem;
+  }
+
+  .services-grid {
+    padding-inline: 1rem;
+  }
+
+  .service-extras {
+    margin-inline: 1rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .services-btn {
+    width: 100%;
+  }
+
+  .service-card {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a services catalog page with hero CTA, categorized offerings, and extras section
- style the new page with responsive layout, benefit lists, and technology tags
- register the services route and expose it from the main navigation

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e56ae8d8988326ab1f6d17054344e1