### PR TITLE
Add navigation controls to timeline gallery

### DIFF
--- a/src/pages/portfolio/Card.js
+++ b/src/pages/portfolio/Card.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { VerticalTimelineElement } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
@@ -26,13 +26,26 @@ const ExperienceCard = ({ theme, experience }) => {
 
   useEffect(() => {
     setCurrentIndex(0);
-    if (images.length <= 1) return;
+  }, [images]);
+
+  useEffect(() => {
+    if (images.length <= 1 || isModalOpen) return undefined;
 
     const interval = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % images.length);
     }, 5000);
 
     return () => clearInterval(interval);
+  }, [images, isModalOpen]);
+
+  const showPrevImage = useCallback(() => {
+    if (!images.length) return;
+    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+  }, [images]);
+
+  const showNextImage = useCallback(() => {
+    if (!images.length) return;
+    setCurrentIndex((prev) => (prev + 1) % images.length);
   }, [images]);
 
   const handleImageClick = () => {
@@ -41,6 +54,16 @@ const ExperienceCard = ({ theme, experience }) => {
   };
 
   const closeModal = () => setIsModalOpen(false);
+
+  const handlePrevClick = (event) => {
+    event.stopPropagation();
+    showPrevImage();
+  };
+
+  const handleNextClick = (event) => {
+    event.stopPropagation();
+    showNextImage();
+  };
 
   return (
     <VerticalTimelineElement
@@ -85,6 +108,26 @@ const ExperienceCard = ({ theme, experience }) => {
         {!!images.length && (
           <div className="experience-carousel">
             <div className="carousel-image-wrapper">
+              {images.length > 1 && (
+                <>
+                  <button
+                    type="button"
+                    className="carousel-arrow left"
+                    onClick={handlePrevClick}
+                    aria-label="Imagen anterior"
+                  >
+                    ‹
+                  </button>
+                  <button
+                    type="button"
+                    className="carousel-arrow right"
+                    onClick={handleNextClick}
+                    aria-label="Imagen siguiente"
+                  >
+                    ›
+                  </button>
+                </>
+              )}
               <img
                 src={images[currentIndex]}
                 alt={`${company} showcase ${currentIndex + 1}`}
@@ -116,6 +159,26 @@ const ExperienceCard = ({ theme, experience }) => {
                 <button className="image-modal-close" type="button" onClick={closeModal} aria-label="Cerrar">
                   ×
                 </button>
+                {images.length > 1 && (
+                  <>
+                    <button
+                      type="button"
+                      className="modal-arrow left"
+                      onClick={handlePrevClick}
+                      aria-label="Imagen anterior"
+                    >
+                      ‹
+                    </button>
+                    <button
+                      type="button"
+                      className="modal-arrow right"
+                      onClick={handleNextClick}
+                      aria-label="Imagen siguiente"
+                    >
+                      ›
+                    </button>
+                  </>
+                )}
                 <img
                   src={images[currentIndex]}
                   alt={`${company} showcase enlarged ${currentIndex + 1}`}

--- a/src/pages/portfolio/style.css
+++ b/src/pages/portfolio/style.css
@@ -62,6 +62,38 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+.carousel-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.carousel-arrow.left {
+  left: 12px;
+}
+
+.carousel-arrow.right {
+  right: 12px;
+}
+
+.carousel-arrow:hover {
+  background: rgba(0, 0, 0, 0.65);
+  transform: translateY(-50%) scale(1.05);
+}
+
 .experience-image {
   display: block;
   width: 100%;
@@ -139,6 +171,37 @@
   font-size: 1.75rem;
   cursor: pointer;
   line-height: 1;
+}
+
+.modal-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(23, 162, 184, 0.75);
+  color: #fff;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.modal-arrow.left {
+  left: 16px;
+}
+
+.modal-arrow.right {
+  right: 16px;
+}
+
+.modal-arrow:hover {
+  background: rgba(23, 162, 184, 0.9);
+  transform: translateY(-50%) scale(1.08);
 }
 .experience-icon {
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- add previous/next controls to the timeline gallery cards and modal views
- pause the automatic image rotation while the modal is open to avoid unexpected changes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6bef20bdc83268533c9eb89e77f19