### PR TITLE
Update services page with responsive card layout

### DIFF
--- a/src/header/index.js
+++ b/src/header/index.js
@@ -40,7 +40,7 @@ const Headermain = ({theme, settheme}) => {
                   <Link  onClick={handleToggle} to="/" className="my-3">Home</Link>
                   </li>
                   <li className="menu_item">
-                  <Link onClick={handleToggle} to="/services" className="my-3">Servicios</Link>
+                  <Link onClick={handleToggle} to="/services" className="my-3">Services</Link>
                   </li>
                   <li className="menu_item">
                   <Link onClick={handleToggle} to="/portfolio" className="my-3">My Professional Timeline</Link>

--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -354,12 +354,12 @@ export const Services = () => {
               <div className="service-card__body">
                 {category.services.map((service) => (
                   <article key={service.name} className="service-item">
-                    <header>
+                    <header className="service-item__header">
                       <h3>{service.name}</h3>
                       <p>{service.description}</p>
                     </header>
                     <div className="service-item__details">
-                      <div>
+                      <div className="service-item__section">
                         <h4>Benefits</h4>
                         <ul>
                           {service.benefits.map((benefit) => (
@@ -367,7 +367,7 @@ export const Services = () => {
                           ))}
                         </ul>
                       </div>
-                      <div>
+                      <div className="service-item__section">
                         <h4>Technologies</h4>
                         <div className="tech-tags">
                           {service.technologies.map((tech) => (

--- a/src/pages/services/style.css
+++ b/src/pages/services/style.css
@@ -120,37 +120,52 @@
   display: grid;
   gap: 1.75rem;
   margin-bottom: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
 }
 
-.service-item h3 {
-  font-size: 1.4rem;
-  margin-bottom: 0.5rem;
+.service-item {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 16px 40px rgba(17, 24, 39, 0.12);
 }
 
-.service-item p {
-  margin-bottom: 1rem;
+.service-item__header h3 {
+  font-size: 1.35rem;
+  margin-bottom: 0.4rem;
+}
+
+.service-item__header p {
+  margin: 0;
   color: var(--text-muted, #7d7d85);
 }
 
 .service-item__details {
+  margin-top: auto;
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.service-item__details h4 {
-  font-size: 1rem;
+.service-item__section h4 {
+  font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted, #7d7d85);
   margin-bottom: 0.75rem;
 }
 
-.service-item__details ul {
-  padding-left: 1.2rem;
+.service-item__section ul {
+  padding-left: 1rem;
   margin: 0;
   color: inherit;
   display: grid;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .tech-tags {
@@ -244,6 +259,10 @@
 
   .service-extras {
     margin-inline: 1rem;
+  }
+
+  .service-item__details {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the services page markup to treat each offering as its own card
- refresh styles so the three offerings sit in one row on desktop and collapse to a single column on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6bf3de1ec83268518fc8048a8180d