### PR TITLE
Add email contact modal to services page

### DIFF
--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -59,7 +59,7 @@ export const Home = () => {
               <div className="hero-card-content">
                 <p className="hero-card-title">REACT, NODE.JS,<br />AWS, AI SYSTEMS</p>
               </div>
-              <Link to="/about" className="hero-card-arrow"><FiArrowUpRight /></Link>
+              <Link to="/services" className="hero-card-arrow"><FiArrowUpRight /></Link>
             </div>
           </div>
         </div>

--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
+import { createPortal } from "react-dom";
 import "./style.css";
 import { Helmet, HelmetProvider } from "react-helmet-async";
 import { Link } from "react-router-dom";
+import { FiMail, FiX, FiCalendar } from "react-icons/fi";
 import { meta } from "../../content_option";
 
 const CALENDLY_URL = "https://calendly.com/serralta-ivan/personal";
@@ -303,7 +305,11 @@ const extras = {
   ],
 };
 
+const EMAIL = "ivanserradev@gmail.com";
+
 export const Services = () => {
+  const [emailModalOpen, setEmailModalOpen] = useState(false);
+
   return (
     <HelmetProvider>
       <section className="services-page">
@@ -325,14 +331,14 @@ export const Services = () => {
               trading automations.
             </p>
             <div className="services-hero__actions">
-              <a
-                href={CALENDLY_URL}
+              <button
+                type="button"
                 className="services-btn services-btn--primary"
-                target="_blank"
-                rel="noreferrer"
+                onClick={() => setEmailModalOpen(true)}
               >
-                Book a free 15-minute call
-              </a>
+                <FiMail style={{ marginRight: "0.5rem" }} />
+                Send me an email
+              </button>
               <Link to="/portfolio" className="services-btn services-btn--ghost">
                 See past work
               </Link>
@@ -429,6 +435,58 @@ export const Services = () => {
           </a>
         </section>
       </section>
+
+      {emailModalOpen && createPortal(
+        <div
+          className="email-modal-overlay"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setEmailModalOpen(false)}
+        >
+          <div className="email-modal" onClick={(e) => e.stopPropagation()}>
+            <button
+              type="button"
+              className="email-modal__close"
+              aria-label="Close"
+              onClick={() => setEmailModalOpen(false)}
+            >
+              <FiX />
+            </button>
+
+            <div className="email-modal__icon-wrap">
+              <FiMail className="email-modal__big-icon" />
+            </div>
+
+            <h2 className="email-modal__title">Get in touch</h2>
+            <p className="email-modal__subtitle">
+              Drop me an email and I'll reply within 24 hours.
+            </p>
+
+            <a
+              href={`mailto:${EMAIL}`}
+              className="email-modal__address"
+            >
+              {EMAIL}
+            </a>
+
+            <div className="email-modal__divider">
+              <span>or prefer a call?</span>
+            </div>
+
+            <a
+              href={CALENDLY_URL}
+              className="services-btn services-btn--primary email-modal__cal-btn"
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => setEmailModalOpen(false)}
+            >
+              <FiCalendar style={{ marginRight: "0.5rem" }} />
+              Book a free 15-minute call
+            </a>
+          </div>
+        </div>,
+        document.body
+      )}
     </HelmetProvider>
   );
 };

--- a/src/pages/services/style.css
+++ b/src/pages/services/style.css
@@ -275,3 +275,125 @@
     padding: 1.5rem;
   }
 }
+
+/* ── Email Modal ── */
+.email-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+.email-modal {
+  position: relative;
+  background: #1a1a2e;
+  border: 1px solid rgba(108, 99, 255, 0.25);
+  border-radius: 28px;
+  padding: 2.5rem 2rem;
+  max-width: 420px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.5);
+  animation: modalIn 0.22s ease;
+}
+
+@keyframes modalIn {
+  from { opacity: 0; transform: scale(0.94) translateY(12px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+
+.email-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: inherit;
+  font-size: 1rem;
+  transition: background 0.15s;
+}
+
+.email-modal__close:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.email-modal__icon-wrap {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(108, 99, 255, 0.2), rgba(138, 116, 255, 0.1));
+  border: 1px solid rgba(108, 99, 255, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.25rem;
+}
+
+.email-modal__big-icon {
+  font-size: 1.5rem;
+  color: #8a74ff;
+}
+
+.email-modal__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.email-modal__subtitle {
+  color: var(--text-muted, #7d7d85);
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+}
+
+.email-modal__address {
+  display: inline-block;
+  background: rgba(108, 99, 255, 0.1);
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  border-radius: 999px;
+  padding: 0.6rem 1.25rem;
+  font-weight: 600;
+  color: #a89eff;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.2s;
+  word-break: break-all;
+}
+
+.email-modal__address:hover {
+  background: rgba(108, 99, 255, 0.2);
+}
+
+.email-modal__divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+  color: var(--text-muted, #7d7d85);
+  font-size: 0.85rem;
+}
+
+.email-modal__divider::before,
+.email-modal__divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.email-modal__cal-btn {
+  width: 100%;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
This PR adds an email contact modal to the services page, providing users with an alternative way to get in touch. The modal offers both direct email contact and a link to schedule a call via Calendly.

## Key Changes
- **New Email Modal Component**: Added a styled modal dialog (`email-modal-overlay` and `email-modal` classes) with smooth entrance animation that displays contact options
- **Modal Styling**: Comprehensive CSS for the modal including:
  - Semi-transparent backdrop with blur effect
  - Gradient icon wrapper with purple accent colors
  - Responsive design with proper padding and max-width constraints
  - Hover states for interactive elements
  - Divider with "or prefer a call?" text
- **Services Page Updates**:
  - Changed primary CTA from "Book a free 15-minute call" link to "Send me an email" button that opens the modal
  - Integrated React state management (`useState`) to control modal visibility
  - Used `createPortal` to render modal at document body level for proper z-index stacking
  - Added proper accessibility attributes (`role="dialog"`, `aria-modal="true"`, `aria-label`)
  - Implemented click-outside-to-close functionality with event propagation handling
- **Home Page Navigation Fix**: Updated hero card link from `/about` to `/services` for better user flow
- **Icon Integration**: Added Feather icons (`FiMail`, `FiX`, `FiCalendar`) for visual consistency

## Implementation Details
- Modal uses a fixed overlay with `inset: 0` for full-screen coverage
- Smooth `modalIn` keyframe animation (0.22s) for entrance effect
- Email address stored as constant `EMAIL` for easy maintenance
- Close button positioned absolutely in top-right corner with semi-transparent styling
- Calendly link remains accessible within the modal as a secondary option
- All interactive elements have appropriate transitions and hover states

https://claude.ai/code/session_01UJNuB4tQbwsBxgNnD3JDgB