### PR TITLE
Improve mobile landing: compact profile card, hero CTAs, tighter layout

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -76,25 +76,54 @@
     width: 100%;
     height: auto;
     position: relative;
-    padding: 24px 20px 16px;
+    padding: 14px 16px 12px;
     border-left: none;
     border-bottom: 1px solid rgba(255, 255, 255, 0.07);
   }
+  /* Compact identity strip: photo + name + badge + socials in one row.
+     The bio is hidden here — the hero right below says the same thing. */
   .app-sidebar .profile-card {
     flex-direction: row;
+    align-items: stretch;
     max-width: 100%;
-    border-radius: 16px;
+    border-radius: 14px;
     overflow: hidden;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25);
   }
   .app-sidebar .profile-image-wrap {
-    width: 110px;
-    height: 130px;
+    width: 86px;
+    height: auto;
+    min-height: 96px;
     flex-shrink: 0;
   }
   .app-sidebar .profile-card-body {
     align-items: flex-start;
     text-align: left;
-    padding: 16px;
+    padding: 12px 14px;
+    gap: 0;
+    justify-content: center;
+  }
+  .app-sidebar .profile-name {
+    font-size: 1.1rem;
+    margin-bottom: 6px;
+  }
+  .app-sidebar .profile-badge {
+    padding: 4px 10px;
+    margin-bottom: 8px;
+  }
+  .app-sidebar .badge-text {
+    font-size: 10px;
+  }
+  .app-sidebar .profile-bio {
+    display: none;
+  }
+  .app-sidebar .profile-socials {
+    gap: 10px;
+  }
+  .app-sidebar .profile-socials a {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
   }
   .app-content {
     border-left: none;

--- a/src/header/style.css
+++ b/src/header/style.css
@@ -15,6 +15,17 @@
   height: 60px;
 }
 
+@media (max-width: 768px) {
+  .header-inner {
+    padding: 0 20px;
+    height: 54px;
+  }
+
+  .nav_ac {
+    font-size: 1rem;
+  }
+}
+
 .menu__button {
   color: var(--text-color);
   background: none;

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,15 @@ body {
   height: 100%;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+/* Anchored sections clear the 60px sticky header */
+section[id] {
+  scroll-margin-top: 72px;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -74,6 +83,13 @@ p {
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+/* The animated cursor is pointless (and distracting) on touch screens */
+@media (hover: none), (pointer: coarse) {
+  .cursor__dot {
+    display: none;
+  }
 }
 
 .cursor__dot div {

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -30,6 +30,14 @@ export const Home = () => {
           <p className="hero-desc">
             I build multi-tenant AI products — WhatsApp bots with Claude + RAG, and custom product configurators with Stripe. Currently shipping for clients in Argentina and Australia.
           </p>
+          <div className="hero-cta">
+            <a href="#contact" className="hero-cta-primary">
+              Let's talk <FiArrowUpRight />
+            </a>
+            <a href="#projects" className="hero-cta-secondary">
+              View projects
+            </a>
+          </div>
           <div className="hero-stats">
             <div className="stat-item">
               <span className="stat-number">+5</span>
@@ -50,14 +58,14 @@ export const Home = () => {
             <div className="hero-card orange">
               <BiLayerPlus className="hero-card-icon" />
               <div className="hero-card-content">
-                <p className="hero-card-title">AI WHATSAPP BOTS,<br />RAG, MULTI-TENANT</p>
+                <p className="hero-card-title">AI WHATSAPP BOTS, <br />RAG, MULTI-TENANT</p>
               </div>
               <Link to="/services" className="hero-card-arrow"><FiArrowUpRight /></Link>
             </div>
             <div className="hero-card lime">
               <RiLayoutGridLine className="hero-card-icon" />
               <div className="hero-card-content">
-                <p className="hero-card-title">CLAUDE, NODE.JS,<br />SUPABASE, STRIPE</p>
+                <p className="hero-card-title">CLAUDE, NODE.JS, <br />SUPABASE, STRIPE</p>
               </div>
               <Link to="/services" className="hero-card-arrow"><FiArrowUpRight /></Link>
             </div>

--- a/src/pages/home/style.css
+++ b/src/pages/home/style.css
@@ -141,6 +141,63 @@
   margin: 0 0 40px;
 }
 
+/* CTA row — hidden on desktop (hero cards cover that role), shown on mobile */
+.hero-cta {
+  display: none;
+}
+
+.hero-cta-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 13px 24px;
+  border-radius: 100px;
+  background: var(--accent-orange);
+  color: #fff;
+  font-family: 'Raleway', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-cta-primary:hover,
+.hero-cta-primary:active {
+  color: #fff;
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(232, 93, 4, 0.35);
+}
+
+.hero-cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 13px 24px;
+  border-radius: 100px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: var(--secondary-color);
+  font-family: 'Raleway', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.hero-cta-secondary:hover,
+.hero-cta-secondary:active {
+  border-color: var(--accent-orange);
+  color: var(--accent-orange);
+}
+
+[data-theme="light"] .hero-cta-secondary {
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
 /* Stats */
 .hero-stats {
   display: flex;
@@ -704,25 +761,126 @@
 }
 
 @media (max-width: 768px) {
-  .section-inner,
-  .hero-inner {
-    padding: 50px 24px;
+  .section-inner {
+    padding: 44px 20px;
   }
 
+  .hero-inner {
+    padding: 36px 20px 44px;
+  }
+
+  /* Tighter, punchier hero typography */
+  .hero-title-line1,
+  .hero-title-line2 {
+    font-size: clamp(2.75rem, 13vw, 4.5rem);
+    letter-spacing: -0.02em;
+    line-height: 1.02;
+  }
+
+  .hero-heading {
+    margin-bottom: 16px;
+  }
+
+  .hero-tagline {
+    margin: 14px 0 14px;
+  }
+
+  .hero-tagline span {
+    font-size: 12px;
+  }
+
+  .hero-desc {
+    font-size: 14px;
+    line-height: 1.65;
+    margin-bottom: 24px;
+  }
+
+  /* CTAs surface on mobile — first tappable action above the fold */
+  .hero-cta {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 36px;
+  }
+
+  .hero-cta-primary,
+  .hero-cta-secondary {
+    flex: 1;
+    padding: 14px 10px;
+    font-size: 12px;
+  }
+
+  /* Stats as an even 3-column strip instead of a wrapping row */
   .hero-stats {
-    gap: 16px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 32px;
+    padding-top: 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  [data-theme="light"] .hero-stats {
+    border-top-color: rgba(0, 0, 0, 0.08);
   }
 
   .stat-divider {
     display: none;
   }
 
+  .stat-number {
+    font-size: 1.9rem;
+  }
+
+  .stat-label {
+    font-size: 9px;
+    margin-top: 4px;
+  }
+
+  /* Hero cards collapse into compact horizontal rows */
   .hero-cards {
     flex-direction: column;
+    gap: 10px;
   }
 
   .hero-card {
     max-width: 100%;
+    flex-direction: row;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 18px;
+    border-radius: 14px;
+  }
+
+  .hero-card-icon {
+    font-size: 22px;
+    flex-shrink: 0;
+  }
+
+  .hero-card-title {
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  .hero-card-title br {
+    display: none;
+  }
+
+  .hero-card-arrow {
+    align-self: center;
+    width: 32px;
+    height: 32px;
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
+  /* Section headings scale down with the viewport */
+  .section-title-main,
+  .section-title-dim {
+    font-size: clamp(2.1rem, 10vw, 3rem);
+  }
+
+  .section-heading {
+    margin-bottom: 32px;
   }
 
   .exp-row {
@@ -746,6 +904,10 @@
 
   .skills-grid {
     grid-template-columns: 1fr;
+  }
+
+  .project-row {
+    padding: 20px 0;
   }
 }
 


### PR DESCRIPTION
- Compact the profile card into an identity strip on mobile (photo, name,
  badge, socials) and hide the bio there since the hero repeats it
- Add Let's talk / View projects CTA buttons in the hero, mobile-only
- Scale down hero and section typography on small screens
- Lay out stats as an even 3-column strip with a top rule
- Collapse hero cards into compact horizontal rows
- Hide the animated cursor on touch devices
- Smooth-scroll anchors with sticky-header offset

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYmk6noFXVUMQ4sW9vhLUy